### PR TITLE
Improves MinHash and bumps version to 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,11 @@ false
 comparing the [Jaccard
 similarity](http://en.wikipedia.org/wiki/Jaccard_index) of two sets.
 
+This implementation includes the improvements recommended in
+"[Improved Densification of One Permutation Hashing]
+(http://arxiv.org/abs/1406.4784)", which greatly reduces the
+time order for building a MinHash.
+
 To `create` a MinHash, you may provide a target error rate for
 similarity (default is 0.05). After that, you can either `insert`
 individual values or add collections `into` the MinHash.
@@ -220,9 +225,9 @@ test> (def hamlet-hash (min-hash/into (min-hash/create) hamlet-tokens))
 test> (def midsummer1-hash (min-hash/into (min-hash/create) midsummer-part1))
 test> (def midsummer2-hash (min-hash/into (min-hash/create) midsummer-part2))
 test> (min-hash/jaccard-similarity midsummer1-hash midsummer2-hash)
-0.2575
+0.2852
 test> (min-hash/jaccard-similarity midsummer1-hash hamlet-hash)
-0.2025
+0.2012
 ```
 
 The MinHashes are merge friendly as long as they're initialized with

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ similarity](http://en.wikipedia.org/wiki/Jaccard_index) of two sets.
 This implementation includes the improvements recommended in
 "[Improved Densification of One Permutation Hashing]
 (http://arxiv.org/abs/1406.4784)", which greatly reduces the
-time order for building a MinHash.
+algorithmic complexity for building a MinHash.
 
 To `create` a MinHash, you may provide a target error rate for
 similarity (default is 0.05). After that, you can either `insert`

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject bigml/sketchy "0.3.1"
+(defproject bigml/sketchy "0.4.0"
   :description "Sketching algorithms in Clojure"
   :url "https://github.com/bigmlcom/sketchy"
   :license {:name "Apache License, Version 2.0"
@@ -8,6 +8,6 @@
   :source-paths ["src/clj"]
   :java-source-paths ["src/java"]
   :jvm-opts ^:replace ["-server"]
-  :profiles {:dev {:plugins [[jonase/eastwood "0.1.4"]]}}
+  :profiles {:dev {:plugins [[jonase/eastwood "0.2.3"]]}}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [byte-transforms "0.1.3"]])
+                 [byte-transforms "0.1.4"]])

--- a/src/clj/bigml/sketchy/min_hash.clj
+++ b/src/clj/bigml/sketchy/min_hash.clj
@@ -1,35 +1,50 @@
-;; Copyright 2013, 2014, 2015 BigML
+;; Copyright 2013, 2014, 2015, 2016 BigML
 ;; Licensed under the Apache License, Version 2.0
 ;; http://www.apache.org/licenses/LICENSE-2.0
 
 (ns bigml.sketchy.min-hash
   "Functions for constructing a min hash.
-   http://en.wikipedia.org/wiki/MinHash"
+   http://en.wikipedia.org/wiki/MinHash
+
+   Also includes improvements recommended in:
+   'Improved Densification of One Permutation Hashing'
+   http://arxiv.org/abs/1406.4784"
   (:refer-clojure :exclude [merge into])
-  (:import (java.lang Math))
+  (:import (java.lang Math)
+           (java.util BitSet))
   (:require (bigml.sketchy [murmur :as murmur])))
+
+(def ^:private max-long Long/MAX_VALUE)
+
+(defn- make-rand-shifts [bits]
+  (let [arr (make-array Long/TYPE 1)
+        _ (aset-long arr 0 bits)
+        bs (BitSet/valueOf arr)]
+    (for [i (range 64)] (.get bs i))))
+
+(def ^:private rand-shifts
+  (mapcat make-rand-shifts (iterate murmur/hash 1)))
 
 (defn create
   "Create a min-hash with an optional desired error rate when
    calculating similarity estimates (defaults to 0.05)."
   ([] (create 0.05))
   ([error-rate]
-     (vec (repeat (int (Math/ceil (/ (* error-rate error-rate))))
-                  Long/MAX_VALUE))))
+   (let [min-size (/ (* error-rate error-rate))]
+     (vec (repeat (->> (iterate (partial * 2) 128)
+                       (drop-while #(< % min-size))
+                       (first))
+                  max-long)))))
 
 (defn- insert* [sketch val]
-  (let [sketch-size (count sketch)]
-    (loop [i 0
-           hashes (murmur/hash-seq val)
-           sketch sketch]
-      (if (= i sketch-size)
-        sketch
-        (let [h (first hashes)]
-          (recur (inc i)
-                 (next hashes)
-                 (if (> (sketch i) h)
-                   (assoc sketch i h)
-                   sketch)))))))
+  (let [hv (murmur/hash val)
+        index (bit-and (dec (count sketch)) hv)
+        hv2 (->> (count sketch)
+                 (Long/numberOfTrailingZeros)
+                 (bit-shift-right hv))]
+    (if (> (sketch index) hv2)
+      (assoc sketch index hv2)
+      sketch)))
 
 (defn insert
   "Inserts one or more values into the min-hash."
@@ -45,13 +60,40 @@
   (when (not= (count sketch1) (count sketch2))
     (throw (Exception. "Min-hash sketches must be the same size."))))
 
+(defn- densify
+  "Densifies the min-hash sketch so it may be used for similarity
+   estimation."
+  [sketch]
+  (let [filled-bins (remove #(= % max-long) sketch)]
+    (loop [result []
+           bins sketch
+           filled-bins (cons (last filled-bins) (cycle filled-bins))
+           shifts rand-shifts]
+      (cond (empty? bins) result
+            (empty? filled-bins) bins
+            (= (first bins) max-long)
+            (recur (conj result
+                         (if (first shifts)
+                           (first filled-bins)
+                           (second filled-bins)))
+                   (next bins)
+                   filled-bins
+                   (next shifts))
+            :else
+            (recur (conj result (first bins))
+                   (next bins)
+                   (next filled-bins)
+                   (next shifts))))))
+
 (defn jaccard-similarity
   "Calculates an estimate of the Jaccard similarity between the sets
    each sketch represents."
   [sketch1 sketch2]
   (check-size! sketch1 sketch2)
-  (double (/ (count (filter true? (map = sketch1 sketch2)))
-             (count sketch1))))
+  (-> (filter true? (map = (densify sketch1) (densify sketch2)))
+      (count)
+      (/ (count sketch1))
+      (double)))
 
 (defn- merge* [sketch1 sketch2]
   (check-size! sketch1 sketch2)

--- a/test/bigml/sketchy/test/min_hash.clj
+++ b/test/bigml/sketchy/test/min_hash.clj
@@ -23,5 +23,7 @@
         (mh/jaccard-similarity (mh/into (mh/create) (range 0.0 1E6))
                                (mh/into (mh/create) (range 1E5 1E6)))
         end (System/currentTimeMillis)]
-    (is (< (- end start) 1000))
+    ;; On a 2.2 GHz Intel Core i7 this takes ~160 seconds before
+    ;; commit e7a629b, after those changes it takes ~300 ms
+    (is (< (- end start) 10000))
     (is (< 0.85 similarity 0.95))))

--- a/test/bigml/sketchy/test/min_hash.clj
+++ b/test/bigml/sketchy/test/min_hash.clj
@@ -1,4 +1,4 @@
-;; Copyright 2013, 2014 BigML
+;; Copyright 2013, 2014, 2015, 2016 BigML
 ;; Licensed under the Apache License, Version 2.0
 ;; http://www.apache.org/licenses/LICENSE-2.0
 
@@ -16,3 +16,12 @@
                                              (mh/into (mh/create)
                                                       (range 500 1500)))
                                    (mh/into (mh/create) (range 1500))))))
+
+(deftest speed-test
+  (let [start (System/currentTimeMillis)
+        similarity
+        (mh/jaccard-similarity (mh/into (mh/create) (range 0.0 1E6))
+                               (mh/into (mh/create) (range 1E5 1E6)))
+        end (System/currentTimeMillis)]
+    (is (< (- end start) 1000))
+    (is (< 0.85 similarity 0.95))))


### PR DESCRIPTION
With this PR, I've added an improvement to MinHash that I've been itching to do for months.  It considerably reduces the time order of MinHash using the techniques described in:

- [One Permutation Hashing](http://papers.nips.cc/paper/4778-one-permutation-hashing.pdf)
- [Improved Densification of One Permutation Hashing](http://arxiv.org/abs/1406.4784)

This will be useful when/if we use MinHash for locality sensitive hashing.