### PR TITLE
Updates to Clojure 1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@
 `sketchy` is available as a Maven artifact from
 [Clojars](http://clojars.org/bigml/sketchy).
 
-For [Leiningen](https://github.com/technomancy/leiningen):
-
-[![Clojars Project](http://clojars.org/bigml/sketchy/latest-version.svg)]
-(http://clojars.org/bigml/sketchy)
+[![Clojars Project](https://img.shields.io/clojars/v/bigml/sketchy.svg)](https://clojars.org/bigml/sketchy)
 
 ## Overview
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject bigml/sketchy "0.4.1"
+(defproject bigml/sketchy "0.4.2"
   :description "Sketching algorithms in Clojure"
   :url "https://github.com/bigmlcom/sketchy"
   :license {:name "Apache License, Version 2.0"
@@ -9,5 +9,5 @@
   :java-source-paths ["src/java"]
   :jvm-opts ^:replace ["-server"]
   :profiles {:dev {:plugins [[jonase/eastwood "0.2.3"]]}}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [byte-transforms "0.1.4"]])


### PR DESCRIPTION
Bumps sketchy to version `0.4.2`.