### PR TITLE
[#15] Upgrade to clj-commons/byte-transforms 0.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ pom.xml
 .lein-deps-sum
 .lein-failures
 .nrepl*
+
+.clj-kondo/.cache
+.lsp/.cache
+.portal/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml
 .clj-kondo/.cache
 .lsp/.cache
 .portal/
+.cpcache

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ comparing the [Jaccard
 similarity](http://en.wikipedia.org/wiki/Jaccard_index) of two sets.
 
 This implementation includes the improvements recommended in
-"[Improved Densification of One Permutation Hashing](http://arxiv.org/abs/1406.4784)", 
+"[Improved Densification of One Permutation Hashing](http://arxiv.org/abs/1406.4784)",
 which greatly reduces the algorithmic complexity for building a MinHash.
 
 To `create` a MinHash, you may provide a target error rate for
@@ -333,6 +333,10 @@ test> (count-min/estimate-count (count-min/merge midsummer1-cm midsummer2-cm)
                                 "love")
 104
 ```
+
+## Contributing to this project
+
+See doc/contributing.md
 
 ## License
 

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# vim: ft=bash
+
+set -e
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+find-latest() {
+    local file latest
+    for file in $(find "$1" -type f -name "*.$2"); do
+        [[ -z $latest || $file -nt $latest ]] && latest=$file
+    done
+    echo $latest
+}
+
+if [[ $1 = clean ]]; then
+    rm -rf target
+elif [[ $1 = hiera ]]; then
+    shift
+    exec clojure -J-Dclojure.main.report=stderr -X:hiera "$@"
+elif [[ $1 = javac ]]; then
+    shift
+    if [[ ! -d target/classes || $(find-latest src/java java) -nt $(find-latest target/classes class) ]]; then
+        echo "Compiling Java class files"
+        exec clojure -J-Dclojure.main.report=stderr -T:build javac "$@"
+    fi
+elif [[ $1 = deploy ]]; then
+    shift
+    if [[ -z $CLOJARS_USERNAME ]]; then
+        read -p "Clojars username: " CLOJARS_USERNAME
+        if [[ -z $CLOJARS_USERNAME ]]; then
+            echo "No username available, aborting" >&2
+            exit 1
+        fi
+        export CLOJARS_USERNAME
+    fi
+    if [[ -z $CLOJARS_PASSWORD ]]; then
+        read -p "Clojars deploy token: " CLOJARS_PASSWORD
+        if [[ -z $CLOJARS_PASSWORD ]]; then
+            echo "No deploy token available, aborting" >&2
+            exit 1
+        fi
+        export CLOJARS_PASSWORD
+    fi
+    exec clojure -J-Dclojure.main.report=stderr -T:build deploy "$@"
+else
+    exec clojure -J-Dclojure.main.report=stderr -T:build "$@"
+fi

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# vim: ft=bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+bin/build javac
+
+if [[ $1 = check ]]; then
+    exec clojure -M:check
+elif [[ $1 = coverage ]]; then
+    shift
+    exec clojure -M:coverage "$@"
+else
+    exec clojure -M:test "$@"
+fi

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,95 @@
+(ns build
+  "Build instructions for sketchy"
+  (:require
+    [clojure.java.io :as io]
+    [clojure.string :as str]
+    [clojure.tools.build.api :as b]
+    [deps-deploy.deps-deploy :as d]))
+
+
+(def lib-name 'bigml/sketchy)
+(def version (str "0.4." (b/git-count-revs nil)))
+
+(def clojure-src-dir "src/clj")
+(def java-src-dir "src/java")
+(def class-dir "target/classes")
+(def jar-file (format "target/%s-%s.jar" (name lib-name) version))
+
+(def basis (b/create-basis {:project "deps.edn"}))
+
+
+(defn clean
+  "Remove compiled artifacts."
+  [_]
+  (b/delete {:path "target"}))
+
+
+(defn javac
+  "Compile Java source files in the project."
+  [_]
+  (let [java-version (System/getProperty "java.version")]
+    (when-not (str/starts-with? java-version "1.8")
+      (binding [*out* *err*]
+        (println "Library should be compiled with Java 1.8 for maximum"
+                 "compatibility; currently using:" java-version))))
+  (b/javac
+    {:src-dirs [java-src-dir]
+     :class-dir class-dir
+     :javac-opts ["-Xlint:unchecked"]
+     :basis basis}))
+
+
+(defn pom
+  "Write out a pom.xml file for the project."
+  [_]
+  (let [commit-sha (b/git-process {:git-args "rev-parse HEAD"})]
+    (b/write-pom
+      {:basis basis
+       :lib lib-name
+       :version version
+       :src-pom "src/pom.xml"
+       :src-dirs [clojure-src-dir]
+       :class-dir class-dir
+       :scm {:tag commit-sha}})))
+
+
+(defn jar
+  "Build a JAR file for distribution."
+  [_]
+  (javac nil)
+  (pom nil)
+  (b/copy-dir
+    {:src-dirs [clojure-src-dir]
+     :target-dir class-dir})
+  (b/jar
+    {:class-dir class-dir
+     :jar-file jar-file}))
+
+
+(defn install
+  "Install a JAR into the local Maven repository."
+  [_]
+  (when-not (.exists (io/file jar-file))
+    (jar nil))
+  (b/install
+    {:basis basis
+     :lib lib-name
+     :version version
+     :jar-file jar-file
+     :class-dir class-dir}))
+
+
+(defn deploy
+  "Deploy the JAR to Clojars."
+  [opts]
+  (when-not (.exists (io/file jar-file))
+    (jar nil))
+  (let [pom-file (b/pom-path
+                   {:class-dir class-dir
+                    :lib lib-name})]
+    (d/deploy
+      (assoc opts
+             :installer :remote
+             :sign-releases? true
+             :pom-file pom-file
+             :artifact jar-file))))

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,25 @@
+{:description "Sketching algorithms in Clojure"
+ :url "https://github.com/bigmlcom/sketchy"
+ :license {:name "Apache License, Version 2.0"
+           :url "http://www.apache.org/licenses/LICENSE-2.0"}
+ :paths ["src/clj" "target/classes"]
+ :deps {org.clj-commons/byte-transforms {:mvn/version "0.2.1"}}
+ :deps/prep-lib {:ensure "target/classes"
+                 :alias :build
+                 :fn javac}
+
+ :aliases {:dev {:extra-deps {}}
+           :build
+           {:deps {org.clojure/clojure {:mvn/version "1.11.1"}
+                   org.slf4j/slf4j-api {:mvn/version "2.0.6"}
+                   org.clojure/tools.build {:mvn/version "0.8.4"}
+                   slipset/deps-deploy {:git/url "https://github.com/slipset/deps-deploy.git"
+                                        :git/sha "c6c67a065dc24ef61cae756ec836e0db179b767f"}}
+            :ns-default build}
+           :test
+           {:extra-paths ["test"]
+            :extra-deps {lambdaisland/kaocha {:mvn/version "1.84.1335"}}
+            :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
+                       "-Duser.language=en"
+                       "-Duser.country=US"]
+            :main-opts ["-m" "kaocha.runner"]}}}

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -1,0 +1,20 @@
+# Contributing to sketchy
+
+
+## Build using deps.edn
+
+We made some scripts to build via deps.edn
+
+```
+# Compile java files with javac
+./bin/build javac
+
+# Build the jar
+./bin/build jar
+
+# Run tests
+./bin/test
+
+# Deploy a new version to clojars (maintainers only)
+./bin/build deploy
+```

--- a/project.clj
+++ b/project.clj
@@ -10,4 +10,4 @@
   :jvm-opts ^:replace ["-server"]
   :profiles {:dev {:plugins [[jonase/eastwood "0.2.3"]]}}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [byte-transforms "0.1.4"]])
+                 [org.clj-commons/byte-transforms "0.2.2"]])

--- a/tests.edn
+++ b/tests.edn
@@ -1,0 +1,5 @@
+#kaocha/v1
+{:tests [{:id :unit
+          :test-paths ["test/"]
+          :ns-patterns ["bigml.sketchy.test.*"]}]
+ :reporter [kaocha.report/documentation]}


### PR DESCRIPTION
* Changed group id to match clj-commons migration
* Added deps.edn support to build the library and deploy to clojars
* This allows the lib to be used from git (via deps.edn) without requiring a release -> helps test out things before a release
* building jar via deps will use version with number of commits at the end: `target/sketchy-0.4.31.jar`
* Fixes #15 